### PR TITLE
Allow unauthenticated OPTIONS requests for CORS preflight

### DIFF
--- a/src/main/java/com/leadsyncpro/config/SecurityConfig.java
+++ b/src/main/java/com/leadsyncpro/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.leadsyncpro.security.JwtAuthenticationFilter;
 import com.leadsyncpro.security.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer; // Yeni import
@@ -84,6 +85,7 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandling -> exceptionHandling.authenticationEntryPoint(unauthorizedHandler))
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/users/invite/accept").permitAll() // <-- burayı ekledik
                         .requestMatchers("/api/integrations/oauth2/**").permitAll()


### PR DESCRIPTION
## Summary
- allow OPTIONS requests to bypass authentication so browsers can complete CORS preflight checks

## Testing
- ./gradlew test *(fails: permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_68e6178801f083239adfa9348c1ac1ff