### PR TITLE
Expose lead sales details via API

### DIFF
--- a/src/main/java/com/leadsyncpro/controller/LeadController.java
+++ b/src/main/java/com/leadsyncpro/controller/LeadController.java
@@ -3,7 +3,6 @@ package com.leadsyncpro.controller;
 import com.leadsyncpro.dto.*;
 import com.leadsyncpro.model.Lead;
 import com.leadsyncpro.model.LeadActivityLog;
-import com.leadsyncpro.model.LeadStatus;
 import com.leadsyncpro.model.LeadStatusLog;
 import com.leadsyncpro.repository.LeadStatusLogRepository;
 import com.leadsyncpro.security.UserPrincipal;
@@ -70,8 +69,8 @@ public class LeadController {
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ADMIN', 'USER', 'SUPER_ADMIN')")
-    public ResponseEntity<Lead> getLeadById(@PathVariable UUID id,
-                                            @AuthenticationPrincipal UserPrincipal currentUser) {
+    public ResponseEntity<LeadResponse> getLeadById(@PathVariable UUID id,
+                                                    @AuthenticationPrincipal UserPrincipal currentUser) {
         return ResponseEntity.ok(leadService.getLeadById(id, currentUser.getOrganizationId()));
     }
 
@@ -98,10 +97,10 @@ public class LeadController {
 
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN', 'SUPER_ADMIN')")
-    public ResponseEntity<Lead> updateLeadStatus(@PathVariable UUID id,
-                                                 @RequestParam LeadStatus status,
-                                                 @AuthenticationPrincipal UserPrincipal currentUser) {
-        Lead updated = leadService.updateLeadStatus(id, status, currentUser.getId());
+    public ResponseEntity<LeadResponse> updateLeadStatus(@PathVariable UUID id,
+                                                         @Valid @RequestBody LeadStatusUpdateRequest request,
+                                                         @AuthenticationPrincipal UserPrincipal currentUser) {
+        LeadResponse updated = leadService.updateLeadStatus(id, request.getStatus(), currentUser.getId(), currentUser.getOrganizationId());
         return ResponseEntity.ok(updated);
     }
 

--- a/src/main/java/com/leadsyncpro/controller/SalesController.java
+++ b/src/main/java/com/leadsyncpro/controller/SalesController.java
@@ -48,6 +48,14 @@ public class SalesController {
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
+    @GetMapping("/{saleId}")
+    @PreAuthorize("hasAnyAuthority('ADMIN','USER','SUPER_ADMIN')")
+    public ResponseEntity<SaleResponse> getSaleById(@PathVariable UUID saleId,
+                                                   @AuthenticationPrincipal UserPrincipal currentUser) {
+        SaleResponse response = salesService.getSaleById(saleId, currentUser.getOrganizationId());
+        return ResponseEntity.ok(response);
+    }
+
     /**
      * 📁 Belge indirme veya görüntüleme
      * - PDF, JPG, PNG gibi dosyalar tarayıcıda açılır.

--- a/src/main/java/com/leadsyncpro/dto/LeadResponse.java
+++ b/src/main/java/com/leadsyncpro/dto/LeadResponse.java
@@ -1,0 +1,23 @@
+package com.leadsyncpro.dto;
+
+import com.leadsyncpro.model.LeadStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeadResponse {
+    private UUID id;
+    private String name;
+    private LeadStatus status;
+    private String phone;
+    private String messengerPageId;
+    private UUID lastSaleId;
+    private SaleResponse lastSale;
+}

--- a/src/main/java/com/leadsyncpro/dto/LeadStatusUpdateRequest.java
+++ b/src/main/java/com/leadsyncpro/dto/LeadStatusUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.leadsyncpro.dto;
+
+import com.leadsyncpro.model.LeadStatus;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class LeadStatusUpdateRequest {
+    @NotNull
+    private LeadStatus status;
+}

--- a/src/main/java/com/leadsyncpro/dto/SaleResponse.java
+++ b/src/main/java/com/leadsyncpro/dto/SaleResponse.java
@@ -1,21 +1,22 @@
 package com.leadsyncpro.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 import java.util.UUID;
 
-@Builder
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class SaleResponse {
     private UUID id;
-    private String operationType;
-    private Double price;
+    private UUID leadId;
+    private String productName;
+    private Double amount;
     private String currency;
-    private String hotel;
-    private Integer nights;
-    private String documentPath;
     private Instant createdAt;
 }
-

--- a/src/main/java/com/leadsyncpro/repository/SalesRepository.java
+++ b/src/main/java/com/leadsyncpro/repository/SalesRepository.java
@@ -3,7 +3,10 @@ package com.leadsyncpro.repository;
 import com.leadsyncpro.model.Sale;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface SalesRepository extends JpaRepository<Sale, UUID> {
+    Optional<Sale> findTopByLead_IdAndOrganizationIdOrderByCreatedAtDesc(UUID leadId, UUID organizationId);
+    Optional<Sale> findByIdAndOrganizationId(UUID saleId, UUID organizationId);
 }

--- a/src/main/java/com/leadsyncpro/service/SalesService.java
+++ b/src/main/java/com/leadsyncpro/service/SalesService.java
@@ -65,16 +65,14 @@ public class SalesService {
 
         Sale saved = salesRepository.save(sale);
 
-        return SaleResponse.builder()
-                .id(saved.getId())
-                .operationType(saved.getOperationType())
-                .price(saved.getPrice())
-                .currency(saved.getCurrency())
-                .hotel(saved.getHotel())
-                .nights(saved.getNights())
-                .documentPath(saved.getDocumentPath())
-                .createdAt(saved.getCreatedAt())
-                .build();
+        return mapToSaleResponse(saved);
+    }
+
+    public SaleResponse getSaleById(UUID saleId, UUID organizationId) {
+        Sale sale = salesRepository.findByIdAndOrganizationId(saleId, organizationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sale not found"));
+
+        return mapToSaleResponse(sale);
     }
 
     private String writeJson(SaleRequest req) {
@@ -84,5 +82,16 @@ public class SalesService {
             log.warn("Transfer JSON serialization failed: {}", e.getMessage());
             return "[]";
         }
+    }
+
+    private SaleResponse mapToSaleResponse(Sale sale) {
+        return SaleResponse.builder()
+                .id(sale.getId())
+                .leadId(sale.getLead() != null ? sale.getLead().getId() : null)
+                .productName(sale.getOperationType())
+                .amount(sale.getPrice())
+                .currency(sale.getCurrency())
+                .createdAt(sale.getCreatedAt())
+                .build();
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated LeadResponse DTO including optional last sale payload
- expose GET /api/sales/{id} and return updated sale schema
- enrich lead status update endpoint to accept JSON payload and respond with lead details

## Testing
- `bash ./gradlew test` *(fails: Gradle wrapper cannot download dependencies through proxy in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e63a905f3c8323b5a4938ec0949a9f