### PR TITLE
Fix lead status update handling and builder defaults

### DIFF
--- a/src/main/java/com/leadsyncpro/controller/LeadController.java
+++ b/src/main/java/com/leadsyncpro/controller/LeadController.java
@@ -100,14 +100,14 @@ public class LeadController {
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN', 'SUPER_ADMIN')")
     public ResponseEntity<LeadResponse> updateLeadStatus(@PathVariable UUID id,
-                                                         @RequestParam(value = "status", required = false) LeadStatus statusParam,
+                                                         @RequestParam(value = "status", required = false) String statusParam,
                                                          @RequestBody(required = false) LeadStatusUpdateRequest request,
                                                          @AuthenticationPrincipal UserPrincipal currentUser) {
-        LeadStatus requestedStatus = null;
-        if (request != null) {
+        String requestedStatus = null;
+        if (request != null && request.getStatus() != null && !request.getStatus().isBlank()) {
             requestedStatus = request.getStatus();
         }
-        if (requestedStatus == null) {
+        if (requestedStatus == null && statusParam != null && !statusParam.isBlank()) {
             requestedStatus = statusParam;
         }
 

--- a/src/main/java/com/leadsyncpro/model/LeadActivityLog.java
+++ b/src/main/java/com/leadsyncpro/model/LeadActivityLog.java
@@ -32,5 +32,6 @@ public class LeadActivityLog {
     private String details;    // serbest metin
 
     @Column(name = "created_at", nullable = false)
+    @Builder.Default
     private Instant createdAt = Instant.now();
 }

--- a/src/main/java/com/leadsyncpro/model/User.java
+++ b/src/main/java/com/leadsyncpro/model/User.java
@@ -50,6 +50,7 @@ public class User {
     private Role role;
 
     @Column(name = "is_active")
+    @Builder.Default
     private boolean isActive = true;
 
     @ElementCollection(targetClass = SupportedLanguages.class)
@@ -61,6 +62,7 @@ public class User {
     private Integer dailyCapacity;
 
     @Column(name = "auto_assign_enabled")
+    @Builder.Default
     private boolean autoAssignEnabled = false;
 
     @Column(name = "created_at", updatable = false)


### PR DESCRIPTION
## Summary
- ensure lead status updates accept string values from both request body and query parameters before delegating to the service
- add `@Builder.Default` to fields with initialization defaults to avoid Lombok builder warnings

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_b_68e655a7a568832385a8e74b6e4e95ba